### PR TITLE
fix gkeclusterclass zone field

### DIFF
--- a/example.yaml
+++ b/example.yaml
@@ -1,7 +1,7 @@
 apiVersion: gcp.resourcepacks.crossplane.io/v1alpha1
 kind: MinimalGCP
 metadata:
-  name: test-minimal
+  name: test
   annotations:
     "resourcepacks.crossplane.io/keep-defaulting-annotations": "true"
 spec:

--- a/resources/gcp/compute/gkeclusterclass.yaml
+++ b/resources/gcp/compute/gkeclusterclass.yaml
@@ -9,8 +9,7 @@ specTemplate:
   writeConnectionSecretsToNamespace: crossplane-system
   machineType: n1-standard-1
   numNodes: 1
-  locations:
-    - $(REGION)a
+  zone: $(REGION)-b
   networkRef:
     name: network
   subnetworkRef:

--- a/resources/gcp/compute/kustomizeconfig.yaml
+++ b/resources/gcp/compute/kustomizeconfig.yaml
@@ -34,7 +34,7 @@ nameReference:
 # varReference is the list of fields that we tell Kustomize to process for
 # variants.
 varReference:
-  - path: specTemplate/locations
+  - path: specTemplate/zone
     kind: GKEClusterClass
   - path: spec/region
     kind: Subnetwork


### PR DESCRIPTION
`Locations` should have been `zone` since `v1alpha1 GKECluster` does not have support for `locations` field.